### PR TITLE
Support function rte_pmd_bnxt_set_all_queues_drop_en - rev_2

### DIFF
--- a/app/test-pmd/cmdline.c
+++ b/app/test-pmd/cmdline.c
@@ -91,6 +91,9 @@
 #ifdef RTE_LIBRTE_IXGBE_PMD
 #include <rte_pmd_ixgbe.h>
 #endif
+#ifdef RTE_LIBRTE_BNXT_PMD
+#include <rte_pmd_bnxt.h>
+#endif
 #include "testpmd.h"
 
 static struct cmdline *testpmd_cl;
@@ -11289,8 +11292,12 @@ cmd_set_all_queues_drop_en_parsed(
 	struct cmd_all_queues_drop_en_result *res = parsed_result;
 	int ret = 0;
 	int is_on = (strcmp(res->on_off, "on") == 0) ? 1 : 0;
+	struct rte_eth_dev *dev = &rte_eth_devices[res->port_id];
 
-	ret = rte_pmd_ixgbe_set_all_queues_drop_en(res->port_id, is_on);
+	if (strcmp(dev->driver->pci_drv.driver.name, "net_bnxt") == 0)
+		ret = rte_pmd_bnxt_set_all_queues_drop_en(res->port_id, is_on);
+	else
+		ret = rte_pmd_ixgbe_set_all_queues_drop_en(res->port_id, is_on);
 	switch (ret) {
 	case 0:
 		break;

--- a/drivers/net/bnxt/Makefile
+++ b/drivers/net/bnxt/Makefile
@@ -65,6 +65,8 @@ SRCS-$(CONFIG_RTE_LIBRTE_BNXT_PMD) += bnxt_irq.c
 # Export include files
 #
 SYMLINK-y-include +=
+SYMLINK-$(CONFIG_RTE_LIBRTE_BNXT_PMD)-include += rte_pmd_bnxt.h
+
 
 # this lib depends upon:
 DEPDIRS-$(CONFIG_RTE_LIBRTE_BNXT_PMD) += lib/librte_mbuf

--- a/drivers/net/bnxt/bnxt.h
+++ b/drivers/net/bnxt/bnxt.h
@@ -58,6 +58,7 @@ struct bnxt_pf_info {
 #define BNXT_FIRST_PF_FID	1
 #define BNXT_MAX_VFS(bp)	(bp->pf.max_vfs)
 #define BNXT_FIRST_VF_FID	128
+#define BNXT_MAX_VF_NUM	128
 #define BNXT_PF_RINGS_USED(bp)	bnxt_get_num_queues(bp)
 #define BNXT_PF_RINGS_AVAIL(bp)	(bp->pf.max_cp_rings - BNXT_PF_RINGS_USED(bp))
 
@@ -68,6 +69,8 @@ struct bnxt_pf_info {
 	void			*vf_req_buf;
 	phys_addr_t		vf_req_buf_dma_addr;
 	uint32_t		vf_req_fwd[8];
+	uint16_t		vf_start_vnic[BNXT_MAX_VF_NUM];
+	uint16_t		vf_max_vnics[BNXT_MAX_VF_NUM];
 };
 
 /* Max wait time is 10 * 100ms = 1s */

--- a/drivers/net/bnxt/bnxt.h
+++ b/drivers/net/bnxt/bnxt.h
@@ -58,7 +58,7 @@ struct bnxt_pf_info {
 #define BNXT_FIRST_PF_FID	1
 #define BNXT_MAX_VFS(bp)	(bp->pf.max_vfs)
 #define BNXT_FIRST_VF_FID	128
-#define BNXT_MAX_VF_NUM	128
+#define BNXT_MAX_VF_NUM		128
 #define BNXT_PF_RINGS_USED(bp)	bnxt_get_num_queues(bp)
 #define BNXT_PF_RINGS_AVAIL(bp)	(bp->pf.max_cp_rings - BNXT_PF_RINGS_USED(bp))
 
@@ -69,8 +69,6 @@ struct bnxt_pf_info {
 	void			*vf_req_buf;
 	phys_addr_t		vf_req_buf_dma_addr;
 	uint32_t		vf_req_fwd[8];
-	uint16_t		vf_start_vnic[BNXT_MAX_VF_NUM];
-	uint16_t		vf_max_vnics[BNXT_MAX_VF_NUM];
 };
 
 /* Max wait time is 10 * 100ms = 1s */

--- a/drivers/net/bnxt/bnxt_ethdev.c
+++ b/drivers/net/bnxt/bnxt_ethdev.c
@@ -52,6 +52,7 @@
 #include "bnxt_txr.h"
 #include "bnxt_vnic.h"
 #include "hsi_struct_def_dpdk.h"
+#include "rte_pmd_bnxt.h"
 
 #define DRV_MODULE_NAME		"bnxt"
 static const char bnxt_version[] =
@@ -809,6 +810,33 @@ static int bnxt_rss_hash_update_op(struct rte_eth_dev *eth_dev,
 			bnxt_hwrm_vnic_rss_cfg(bp, vnic);
 		}
 	}
+	return 0;
+}
+
+int rte_pmd_bnxt_set_tx_loopback(uint8_t port, uint8_t on)
+{
+	struct rte_eth_dev 		*eth_dev;
+	struct bnxt 			*bp;
+
+	RTE_ETH_VALID_PORTID_OR_ERR_RET(port, -ENODEV);
+
+	if (on > 1)
+		return -EINVAL;
+
+	eth_dev = &rte_eth_devices[port];
+	bp = (struct bnxt *)eth_dev->data->dev_private;
+
+	if (!BNXT_PF(bp)) {
+		RTE_LOG(ERR, PMD, "Attempt to operate on none-PF!\n");
+		return -ENOTSUP;
+	}
+
+	/* EVB mode fixed on Virtual Edge Bridge(VEB) */
+	if (on == 0) {
+		RTE_LOG(ERR, PMD, "Turning off Edge Virtual Bridge is not supportted now!\n");
+		return -ENOTSUP;
+	}
+
 	return 0;
 }
 

--- a/drivers/net/bnxt/bnxt_ethdev.c
+++ b/drivers/net/bnxt/bnxt_ethdev.c
@@ -311,7 +311,7 @@ static void bnxt_dev_info_get_op(struct rte_eth_dev *eth_dev,
 
 	/* PF/VF specifics */
 	if (BNXT_PF(bp))
-		dev_info->max_vfs = bp->pf.active_vfs;
+		dev_info->max_vfs = bp->pf.max_vfs;
 	dev_info->max_rx_queues = bp->max_rx_rings;
 	dev_info->max_tx_queues = bp->max_tx_rings;
 	dev_info->reta_size = bp->max_rsscos_ctx;

--- a/drivers/net/bnxt/bnxt_ethdev.c
+++ b/drivers/net/bnxt/bnxt_ethdev.c
@@ -263,16 +263,6 @@ static int bnxt_init_chip(struct bnxt *bp)
 		}
 	}
 
-	if (BNXT_PF(bp) && bp->pf.active_vfs > 0) {
-		/* Update each VF's start vnic id */
-		uint16_t fw_vnic_id = bp->vnic_info[0].fw_vnic_id + bp->max_vnics;
-		int j;
-		for (j = bp->pf.active_vfs - 1; j >= 0; j--) {
-			bp->pf.vf_start_vnic[j] = fw_vnic_id;
-			fw_vnic_id += bp->pf.vf_max_vnics[j];
-		}
-	}
-
 	return 0;
 
 err_out:
@@ -831,14 +821,12 @@ int rte_pmd_bnxt_set_tx_loopback(uint8_t port, uint8_t on)
 	return 0;
 }
 
-
 int rte_pmd_bnxt_set_all_queues_drop_en(uint8_t port, uint8_t on)
 {
-	struct rte_eth_dev 		*eth_dev;
-	struct bnxt 			*bp;
-	struct bnxt_vnic_info	*vnic;
-	int						 i;
-	int						 rc;
+	struct rte_eth_dev *eth_dev;
+	struct bnxt *bp;
+	uint32_t i;
+	int rc;
 
 	RTE_ETH_VALID_PORTID_OR_ERR_RET(port, -ENODEV);
 
@@ -856,20 +844,22 @@ int rte_pmd_bnxt_set_all_queues_drop_en(uint8_t port, uint8_t on)
 	if (bp->vnic_info == NULL)
 		return -ENODEV;
 
-	vnic = &bp->vnic_info[0];
-	if (on)
-		vnic->flags &= ~BNXT_VNIC_INFO_UNICAST;
-	else
-		vnic->flags |= BNXT_VNIC_INFO_UNICAST;
-
 	/* Stall PF */
-	rc = bnxt_hwrm_vnic_stall(bp, vnic->fw_vnic_id, on);
+	for (i = 0; i < bp->nr_vnics; i++) {
+		bp->vnic_info[i].bd_stall = on;
+		rc = bnxt_hwrm_vnic_cfg(bp, &bp->vnic_info[i]);
+		if (rc) {
+			RTE_LOG(ERR, PMD, "Failed to update PF VNIC %d.\n", i);
+			return rc;
+		}
+	}
 
 	/* Stall all active VFs */
 	for (i = 0; i < bp->pf.active_vfs; i++) {
 		rc = bnxt_hwrm_func_vf_stall(bp, i, on);
 		if (rc) {
-			RTE_LOG(ERR, PMD, "Failed to update VNIC %d state to: %s.\n", i, on ? "on":"off");
+			RTE_LOG(ERR, PMD, "Failed to update VF VNIC %d.\n", i);
+			break;
 		}
 	}
 

--- a/drivers/net/bnxt/bnxt_hwrm.c
+++ b/drivers/net/bnxt/bnxt_hwrm.c
@@ -154,7 +154,7 @@ static int bnxt_hwrm_send_message(struct bnxt *bp, void *msg, uint32_t msg_len)
 	req.target_id = rte_cpu_to_le_16(0xffff); \
 	req.resp_addr = rte_cpu_to_le_64(bp->hwrm_cmd_resp_dma_addr)
 
-#define HWRM_CHECK_RESPONSE(resp) \
+#define HWRM_CHECK_RESULT \
 	{ \
 		if (rc) { \
 			RTE_LOG(ERR, PMD, "%s failed rc:%d\n", \
@@ -167,8 +167,6 @@ static int bnxt_hwrm_send_message(struct bnxt *bp, void *msg, uint32_t msg_len)
 			return rc; \
 		} \
 	}
-
-#define HWRM_CHECK_RESULT HWRM_CHECK_RESPONSE(resp)
 
 int bnxt_hwrm_cfa_l2_clear_rx_mask(struct bnxt *bp, struct bnxt_vnic_info *vnic)
 {
@@ -845,8 +843,9 @@ int bnxt_hwrm_vnic_cfg(struct bnxt *bp, struct bnxt_vnic_info *vnic)
 	HWRM_PREP(req, VNIC_CFG, -1, resp);
 
 	/* Only RSS support for now TBD: COS & LB */
-	req.enables =
-	    rte_cpu_to_le_32(HWRM_VNIC_CFG_INPUT_ENABLES_DFLT_RING_GRP |
+	if (!vnic->bd_stall)
+		req.enables =
+			rte_cpu_to_le_32(HWRM_VNIC_CFG_INPUT_ENABLES_DFLT_RING_GRP |
 			     HWRM_VNIC_CFG_INPUT_ENABLES_RSS_RULE |
 			     HWRM_VNIC_CFG_INPUT_ENABLES_MRU);
 	req.vnic_id = rte_cpu_to_le_16(vnic->fw_vnic_id);
@@ -862,6 +861,9 @@ int bnxt_hwrm_vnic_cfg(struct bnxt *bp, struct bnxt_vnic_info *vnic)
 	if (vnic->vlan_strip)
 		req.flags |=
 		    rte_cpu_to_le_32(HWRM_VNIC_CFG_INPUT_FLAGS_VLAN_STRIP_MODE);
+	if (vnic->bd_stall)
+		req.flags |=
+			rte_cpu_to_le_32(HWRM_VNIC_CFG_INPUT_FLAGS_BD_STALL_MODE);
 
 	rc = bnxt_hwrm_send_message(bp, &req, sizeof(req));
 
@@ -953,57 +955,50 @@ int bnxt_hwrm_vnic_rss_cfg(struct bnxt *bp,
 	return rc;
 }
 
-int bnxt_hwrm_vnic_stall(struct bnxt *bp, uint16_t fw_vnic_id, uint8_t on)
-{
-	struct hwrm_vnic_cfg_input req = {0};
-	struct hwrm_vnic_cfg_output *resp = bp->hwrm_cmd_resp_addr;
-	int rc = 0;
+#define HW_MAX_VNICS 170
 
-	HWRM_PREP(req, VNIC_CFG, -1, resp);
-
-	if (on)
-		req.flags |= rte_cpu_to_le_32(HWRM_VNIC_CFG_INPUT_FLAGS_BD_STALL_MODE);
-	req.vnic_id = rte_cpu_to_le_16(fw_vnic_id);
-
-	rc = bnxt_hwrm_send_message(bp, &req, sizeof(req));
-
-	HWRM_CHECK_RESULT;
-
-	return rc;
-}
-
-/*
- * func_vf_vnic_ids_query
- * 	vnic_qcfg
- * 	HWRM_VNIC_CFG
- */
 int bnxt_hwrm_func_vf_stall(struct bnxt *bp, uint16_t vf, uint8_t on)
 {
-	struct hwrm_func_vf_vnic_ids_query_input req_vf_vnic_ids = {0};
-	struct hwrm_func_vf_vnic_ids_query_output *resp_vf_vnic_ids = bp->hwrm_cmd_resp_addr;
-	struct hwrm_vnic_cfg_input req_vnic_cfg = {0};
-	struct hwrm_vnic_cfg_output *resp_vnic_cfg = bp->hwrm_cmd_resp_addr;
-	int rc = 0;
-	uint32_t i, vnic_ids;
+	struct hwrm_func_vf_vnic_ids_query_input req = {0};
+	struct hwrm_func_vf_vnic_ids_query_output *resp = bp->hwrm_cmd_resp_addr;
+	struct bnxt_vnic_info vnic;
+	int rc;
+	uint32_t i, num_vnic_ids;
+	uint16_t *vnic_ids;
 
-	HWRM_PREP(req_vf_vnic_ids, FUNC_VF_VNIC_IDS_QUERY, -1, resp_vf_vnic_ids);
-	req_vf_vnic_ids.vf_id = rte_cpu_to_le_16(bp->pf.first_vf_id + vf);
-	rc = bnxt_hwrm_send_message(bp, &req_vf_vnic_ids, sizeof(req_vf_vnic_ids));
-	HWRM_CHECK_RESPONSE(resp_vf_vnic_ids);
+	/* First query all VNIC ids */
 
-	vnic_ids = resp_vf_vnic_ids->vnic_id_cnt;
-
-	HWRM_PREP(req_vnic_cfg, VNIC_CFG, -1, resp_vnic_cfg);
-	if (on)
-		req_vnic_cfg.flags |= rte_cpu_to_le_32(HWRM_VNIC_CFG_INPUT_FLAGS_BD_STALL_MODE);
-
-	for (i = 0; i < vnic_ids; i++) {
-		req_vnic_cfg.vnic_id = rte_cpu_to_le_16(bp->pf.vf_start_vnic[vf] + i);
-		rc = bnxt_hwrm_send_message(bp, &req_vnic_cfg, sizeof(req_vnic_cfg));
-		if (rc || resp_vnic_cfg->error_code) {
-			RTE_LOG(ERR, PMD, "Failed to stall VF %d vnic %d.\n", vf, i);
-		}
+	vnic_ids = rte_malloc("bnxt_hwrm_vf_vnic_ids_query", HW_MAX_VNICS * sizeof(*vnic_ids),
+			RTE_CACHE_LINE_SIZE);
+	if (vnic_ids == NULL) {
+		rc = -ENOMEM;
+		return rc;
 	}
+
+	HWRM_PREP(req, FUNC_VF_VNIC_IDS_QUERY, -1, resp_vf_vnic_ids);
+
+	req.vf_id = rte_cpu_to_le_16(bp->pf.first_vf_id + vf);
+	req.max_vnic_id_cnt = rte_cpu_to_le_32(HW_MAX_VNICS);
+	req.vnic_id_tbl_addr = rte_malloc_virt2phy(vnic_ids);
+
+	rc = bnxt_hwrm_send_message(bp, &req, sizeof(req));
+	HWRM_CHECK_RESULT;
+
+	num_vnic_ids = resp->vnic_id_cnt;
+
+	/* Retrieve VNIC, update bd_stall then update */
+
+	for (i = 0; i < num_vnic_ids; i++) {
+		memset(&vnic, 0, sizeof(struct bnxt_vnic_info));
+		vnic.fw_vnic_id = vnic_ids[i];
+		vnic.bd_stall = on;
+		//TODO bnxt_hwrm_vnic_qcfg(&vnic);
+		//rc = bnxt_hwrm_vnic_cfg(bp, &vnic);
+		if (rc)
+			break;
+	}
+
+	rte_free(vnic_ids);
 
 	return rc;
 }
@@ -1802,8 +1797,6 @@ static void reserve_resources_from_vf(struct bnxt *bp, struct hwrm_func_cfg_inpu
 	bp->max_l2_ctx -= rte_le_to_cpu_16(resp->max_l2_ctxs);
 	bp->max_vnics -= rte_le_to_cpu_16(resp->max_vnics);
 	bp->max_ring_grps -= rte_le_to_cpu_16(resp->max_hw_ring_grps);
-
-	bp->pf.vf_max_vnics[vf] = rte_le_to_cpu_16(resp->max_vnics);
 }
 
 static int update_pf_resource_max(struct bnxt *bp)

--- a/drivers/net/bnxt/bnxt_hwrm.h
+++ b/drivers/net/bnxt/bnxt_hwrm.h
@@ -90,6 +90,8 @@ int bnxt_hwrm_vnic_ctx_free(struct bnxt *bp, struct bnxt_vnic_info *vnic);
 int bnxt_hwrm_vnic_free(struct bnxt *bp, struct bnxt_vnic_info *vnic);
 int bnxt_hwrm_vnic_rss_cfg(struct bnxt *bp,
 			   struct bnxt_vnic_info *vnic);
+int bnxt_hwrm_vnic_stall(struct bnxt *bp, uint16_t fw_vnic_id,
+			   uint8_t on);
 
 int bnxt_alloc_all_hwrm_stat_ctxs(struct bnxt *bp);
 int bnxt_clear_all_hwrm_stat_ctxs(struct bnxt *bp);
@@ -107,5 +109,6 @@ int bnxt_set_hwrm_link_config(struct bnxt *bp, bool link_up);
 int bnxt_hwrm_func_qcfg(struct bnxt *bp);
 int bnxt_hwrm_allocate_pf_only(struct bnxt *bp);
 int bnxt_hwrm_allocate_vfs(struct bnxt *bp, int num_vfs);
+int bnxt_hwrm_func_vf_stall(struct bnxt *bp, uint16_t vf, uint8_t on);
 
 #endif

--- a/drivers/net/bnxt/bnxt_hwrm.h
+++ b/drivers/net/bnxt/bnxt_hwrm.h
@@ -90,7 +90,7 @@ int bnxt_hwrm_vnic_ctx_free(struct bnxt *bp, struct bnxt_vnic_info *vnic);
 int bnxt_hwrm_vnic_free(struct bnxt *bp, struct bnxt_vnic_info *vnic);
 int bnxt_hwrm_vnic_rss_cfg(struct bnxt *bp,
 			   struct bnxt_vnic_info *vnic);
-int bnxt_hwrm_vnic_stall(struct bnxt *bp, uint16_t fw_vnic_id,
+int bnxt_hwrm_vnic_stall(struct bnxt *bp, struct bnxt_vnic_info *vnic,
 			   uint8_t on);
 
 int bnxt_alloc_all_hwrm_stat_ctxs(struct bnxt *bp);

--- a/drivers/net/bnxt/bnxt_vnic.h
+++ b/drivers/net/bnxt/bnxt_vnic.h
@@ -59,6 +59,7 @@ struct bnxt_vnic_info {
 	uint32_t	flags;
 #define BNXT_VNIC_INFO_PROMISC			(1 << 0)
 #define BNXT_VNIC_INFO_ALLMULTI			(1 << 1)
+#define BNXT_VNIC_INFO_UNICAST			(1 << 2)
 
 	bool		vlan_strip;
 	bool		func_default;

--- a/drivers/net/bnxt/bnxt_vnic.h
+++ b/drivers/net/bnxt/bnxt_vnic.h
@@ -59,10 +59,10 @@ struct bnxt_vnic_info {
 	uint32_t	flags;
 #define BNXT_VNIC_INFO_PROMISC			(1 << 0)
 #define BNXT_VNIC_INFO_ALLMULTI			(1 << 1)
-#define BNXT_VNIC_INFO_UNICAST			(1 << 2)
 
 	bool		vlan_strip;
 	bool		func_default;
+	bool		bd_stall;
 
 	STAILQ_HEAD(, bnxt_filter_info)	filter;
 };

--- a/drivers/net/bnxt/hsi_struct_def_dpdk.h
+++ b/drivers/net/bnxt/hsi_struct_def_dpdk.h
@@ -91,6 +91,7 @@ struct ctx_hw_stats64 {
 #define HWRM_FUNC_QCFG			(UINT32_C(0x16))
 #define HWRM_FUNC_CFG			(UINT32_C(0x17))
 #define HWRM_FUNC_DRV_UNRGTR		(UINT32_C(0x1a))
+#define HWRM_FUNC_VF_VNIC_IDS_QUERY	(UINT32_C(0x1c))
 #define HWRM_FUNC_DRV_RGTR		(UINT32_C(0x1d))
 #define HWRM_FUNC_BUF_RGTR		(UINT32_C(0x1f))
 #define HWRM_PORT_PHY_CFG		(UINT32_C(0x20))
@@ -3062,6 +3063,82 @@ struct hwrm_func_drv_unrgtr_output {
 	 * internal processor, the order of writes has to be such that
 	 * this field is written last.
 	 */
+} __attribute__((packed));
+
+/* hwrm_func_vf_vnic_ids_query */
+/* Description: This command is used to query vf vnic ids. */
+/* Input (32 bytes) */
+struct hwrm_func_vf_vnic_ids_query_input
+{
+    uint16_t req_type;
+    /*
+     * This value indicates what type of request this is. The format for the
+     * rest of the command is determined by this field.
+     */
+    uint16_t cmpl_ring;
+    /*
+     * This value indicates the what completion ring the request will be
+     * optionally completed on. If the value is -1, then no CR completion
+     * will be generated. Any other value must be a valid CR ring_id value
+     * for this function.
+     */
+    uint16_t seq_id;
+    /* This value indicates the command sequence number. */
+    uint16_t target_id;
+    /*
+     * Target ID of this command. 0x0 - 0xFFF8 - Used for function ids
+     * 0xFFF8 - 0xFFFE - Reserved for internal processors 0xFFFF - HWRM
+     */
+    uint64_t resp_addr;
+    /*
+     * This is the host address where the response will be written when the
+     * request is complete. This area must be 16B aligned and must be
+     * cleared to zero before the request is made.
+     */
+    uint16_t vf_id;
+    /*
+     * This value is used to identify a Virtual Function (VF). The scope of
+     * VF ID is local within a PF.
+     */
+    uint8_t unused_0;
+    uint8_t unused_1;
+    uint32_t max_vnic_id_cnt;
+    /* Max number of vnic ids in vnic id table */
+    uint32_t vnic_id_tbl_addr[2];
+    /* This is the address for VF VNIC ID table */
+} __attribute__((packed));
+
+/* Output (16 bytes) */
+struct hwrm_func_vf_vnic_ids_query_output
+{
+	uint16_t error_code;
+    /*
+     * Pass/Fail or error type Note: receiver to verify the in parameters,
+     * and fail the call with an error when appropriate
+     */
+    uint16_t req_type;
+    /* This field returns the type of original request. */
+    uint16_t seq_id;
+    /* This field provides original sequence number of the command. */
+    uint16_t resp_len;
+    /*
+     * This field is the length of the response in bytes. The last byte of
+     * the response is a valid flag that will read as '1' when the command
+     * has been completely written to memory.
+     */
+    uint32_t vnic_id_cnt;
+    /* Actual number of vnic ids Each VNIC ID is written as a 32-bit number. */
+    uint8_t unused_0;
+    uint8_t unused_1;
+    uint8_t unused_2;
+    uint8_t valid;
+    /*
+     * This field is used in Output records to indicate that the output is
+     * completely written to RAM. This field should be read as '1' to
+     * indicate that the output has been completely written. When writing a
+     * command completion or response to an internal processor, the order of
+     * writes has to be such that this field is written last.
+     */
 } __attribute__((packed));
 
 /* hwrm_port_phy_cfg */

--- a/drivers/net/bnxt/hsi_struct_def_dpdk.h
+++ b/drivers/net/bnxt/hsi_struct_def_dpdk.h
@@ -3068,8 +3068,7 @@ struct hwrm_func_drv_unrgtr_output {
 /* hwrm_func_vf_vnic_ids_query */
 /* Description: This command is used to query vf vnic ids. */
 /* Input (32 bytes) */
-struct hwrm_func_vf_vnic_ids_query_input
-{
+struct hwrm_func_vf_vnic_ids_query_input {
     uint16_t req_type;
     /*
      * This value indicates what type of request this is. The format for the
@@ -3104,13 +3103,12 @@ struct hwrm_func_vf_vnic_ids_query_input
     uint8_t unused_1;
     uint32_t max_vnic_id_cnt;
     /* Max number of vnic ids in vnic id table */
-    uint32_t vnic_id_tbl_addr[2];
+    uint64_t vnic_id_tbl_addr;
     /* This is the address for VF VNIC ID table */
 } __attribute__((packed));
 
 /* Output (16 bytes) */
-struct hwrm_func_vf_vnic_ids_query_output
-{
+struct hwrm_func_vf_vnic_ids_query_output {
 	uint16_t error_code;
     /*
      * Pass/Fail or error type Note: receiver to verify the in parameters,

--- a/drivers/net/bnxt/rte_pmd_bnxt.h
+++ b/drivers/net/bnxt/rte_pmd_bnxt.h
@@ -52,4 +52,20 @@
  */
 int rte_pmd_bnxt_set_tx_loopback(uint8_t port, uint8_t on);
 
+/**
+ * set all queues drop enable bit
+ *
+ * @param port
+ *    The port identifier of the Ethernet device.
+ * @param on
+ *    1 - set the queue drop enable bit for all pools.
+ *    0 - reset the queue drop enable bit for all pools.
+ *
+ * @return
+ *   - (0) if successful.
+ *   - (-ENODEV) if *port* invalid.
+ *   - (-EINVAL) if bad parameter.
+ */
+int rte_pmd_bnxt_set_all_queues_drop_en(uint8_t port, uint8_t on);
+
 #endif /* _PMD_BNXT_H_ */

--- a/drivers/net/bnxt/rte_pmd_bnxt.h
+++ b/drivers/net/bnxt/rte_pmd_bnxt.h
@@ -1,0 +1,55 @@
+/*-
+ *   BSD LICENSE
+ *
+ *   Copyright(c) Broadcom Limited.
+ *   All rights reserved.
+ *
+ *   Redistribution and use in source and binary forms, with or without
+ *   modification, are permitted provided that the following conditions
+ *   are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *     * Neither the name of Broadcom Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _PMD_BNXT_H_
+#define _PMD_BNXT_H_
+
+#include <rte_ethdev.h>
+
+/**
+ * Enable/Disable tx loopback
+ *
+ * @param port
+ *    The port identifier of the Ethernet device.
+ * @param on
+ *    1 - Enable tx loopback.
+ *    0 - Disable tx loopback.
+ *
+ * @return
+ *   - (0) if successful.
+ *   - (-ENODEV) if *port* invalid.
+ *   - (-EINVAL) if bad parameter.
+ */
+int rte_pmd_bnxt_set_tx_loopback(uint8_t port, uint8_t on);
+
+#endif /* _PMD_BNXT_H_ */

--- a/drivers/net/bnxt/rte_pmd_bnxt_version.map
+++ b/drivers/net/bnxt/rte_pmd_bnxt_version.map
@@ -7,4 +7,5 @@ DPDK_17.02 {
 	global:
 
 	rte_pmd_bnxt_set_tx_loopback;
+	rte_pmd_bnxt_set_all_queues_drop_en;
 };

--- a/drivers/net/bnxt/rte_pmd_bnxt_version.map
+++ b/drivers/net/bnxt/rte_pmd_bnxt_version.map
@@ -2,3 +2,9 @@ DPDK_16.04 {
 
 	local: *;
 };
+
+DPDK_17.02 {
+	global:
+
+	rte_pmd_bnxt_set_tx_loopback;
+};


### PR DESCRIPTION
1. Add bd_stall attribute to bnxt_vnic_info, reuse bnxt_hwrm_vnic_cfg() to configure bd_stall
2. From test, it looks that bd_stall doesn't take effect for PF.
3. Plan to introduce HWRM_VNIC_**Q**CFG for VNIC to retrieve VF's vnic info, then issue HWRM_VNIC_CFG  with sufficient information, is this correct direction?
